### PR TITLE
Fix automagic detection of intrinsics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ libtool
 stamp-h1
 apps/parasail_aligner
 apps/parasail_stats
+parasail-*-uninstalled.pc
+parasail-*-uninstalled.sh
+parasail-*.pc
+parasail-*.pc.in

--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,25 @@ AS_CASE(["$host_cpu"],
 AM_CONDITIONAL([IS_POWER_ISA], [test "x$is_power_isa" = x1])
 
 ###############################################################################
+# --enable options
+###############################################################################
+
+AC_ARG_ENABLE([sse2],
+    [AS_HELP_STRING([--disable-sse2], [disable SSE2 support (default=auto)])], [], [enable_sse2="auto (yes)"])
+
+AC_ARG_ENABLE([sse4_1],
+    [AS_HELP_STRING([--disable-sse4_1], [disable SSE4.1 support (default=auto)])], [], [enable_sse4_1="auto (yes)"])
+
+AC_ARG_ENABLE([avx2],
+    [AS_HELP_STRING([--disable-avx2], [disable AVX2 support (default=auto)])], [], [enable_avx2="auto (yes)"])
+
+AC_ARG_ENABLE([avx512],
+    [AS_HELP_STRING([--disable-avx512], [disable AVX512 support (default=auto)])], [], [enable_avx512="auto (yes)"])
+
+AC_ARG_ENABLE([altivec],
+    [AS_HELP_STRING([--disable-altivec], [disable Altivec support (default=auto)])], [], [enable_altivec="auto (yes)"])
+
+###############################################################################
 # C compiler
 ###############################################################################
 AC_MSG_NOTICE
@@ -77,6 +96,8 @@ AC_MSG_NOTICE([C compiler])
 AC_MSG_NOTICE
 
 AC_PROG_CC
+AX_COMPILER_VENDOR
+AX_COMPILER_VERSION
 
 # Checks for header files.
 AC_CHECK_HEADERS([malloc.h])
@@ -103,108 +124,186 @@ AC_SUBST([OPENMP_CFLAGS])
 AM_CONDITIONAL([HAVE_OPENMP],
                [test "x$ax_cv_[]_AC_LANG_ABBREV[]_openmp" != "xunknown"])
 
-AC_CACHE_CHECK([for SSE2 support], [pt_cv_sse2],
-[pt_cv_sse2=no; pt_cv_sse2_val=0
-for flag in default -msse2 -march=core2
-do 
-     save_CFLAGS="$CFLAGS"
-     AS_IF([test "x$flag" != xdefault], [CFLAGS="$CFLAGS $flag"])
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_LINK_IFELSE([AC_LANG_SOURCE([[
-#include <emmintrin.h>
-int foo() {
-    __m128i vOne = _mm_set1_epi16(1);
-    __m128i result = _mm_add_epi16(vOne,vOne);
-    return _mm_extract_epi16(result, 0);
-}
-int main(void) { return foo(); }
-]])],
-        [pt_cv_sse2="$flag"; pt_cv_sse2_val=1])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"
-     AS_IF([test "x$pt_cv_sse2" != xno], [break])
-done])
-AC_DEFINE_UNQUOTED([HAVE_SSE2], [$pt_cv_sse2_val],
-    [define to 1 if the C compiler supports SSE2])
-AM_CONDITIONAL([HAVE_SSE2], [test "x$pt_cv_sse2_val" = x1])
+###############################################################################
+# SSE2
+###############################################################################
+AS_IF([test "x$enable_sse2" != "xno"], [
+    AC_CACHE_CHECK([for SSE2 support], [pt_cv_sse2],
+    [pt_cv_sse2=no; pt_cv_sse2_val=0
+    for flag in default -msse2
+    do
+         save_CFLAGS="$CFLAGS"
+         AS_IF([test "x$flag" != xdefault], [CFLAGS="$CFLAGS $flag"])
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #include <emmintrin.h>
+    int foo() {
+        __m128i vOne = _mm_set1_epi16(1);
+        __m128i result = _mm_add_epi16(vOne,vOne);
+        return _mm_extract_epi16(result, 0);
+    }
+    int main(void) { return foo(); }
+    ]])],
+            [pt_cv_sse2="$flag"; pt_cv_sse2_val=1])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"
+         AS_IF([test "x$pt_cv_sse2" != xno], [break])
+    done])
+    AC_DEFINE_UNQUOTED([HAVE_SSE2], [$pt_cv_sse2_val],
+        [define to 1 if the C compiler supports SSE2])
+    AS_IF([test "x$pt_cv_sse2_val" != x1], [
+        AS_IF([test "x$enable_sse2" = xyes], [
+            dnl explicitly passed --enable_sse2, hence error out loud and clearly
+            AC_MSG_ERROR([You explicitly requested SSE2 support, but SSE2 CFLAGS could not be found!])
+        ], [
+            enable_sse2="auto (no)"
+        ])
+    ])
+
+    AC_CACHE_CHECK([for SSE2 _mm_set1_epi64x],
+        [pt_cv_sse2_mm_set1_epi64x],
+        [save_CFLAGS="$CFLAGS"
+         CFLAGS="$SSE2_CFLAGS $CFLAGS"
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <emmintrin.h>
+    __m128i foo() {
+        __m128i vOne = _mm_set1_epi64x(1);
+        return vOne;
+    }
+    ]])],
+            [pt_cv_sse2_mm_set1_epi64x=yes;
+             pt_cv_sse2_mm_set1_epi64x_val=1],
+            [pt_cv_sse2_mm_set1_epi64x=no;
+             pt_cv_sse2_mm_set1_epi64x_val=0])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"])
+    AC_DEFINE_UNQUOTED([HAVE_SSE2_MM_SET1_EPI64X],
+        [$pt_cv_sse2_mm_set1_epi64x_val],
+        [define to 1 if the C compiler supports SSE2 _mm_set1_epi64x])
+
+    AC_CACHE_CHECK([for SSE2 _mm_set_epi64x],
+        [pt_cv_sse2_mm_set_epi64x],
+        [save_CFLAGS="$CFLAGS"
+         CFLAGS="$SSE2_CFLAGS $CFLAGS"
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <emmintrin.h>
+    __m128i foo() {
+        __m128i vOne = _mm_set_epi64x(1,1);
+        return vOne;
+    }
+    ]])],
+            [pt_cv_sse2_mm_set_epi64x=yes;
+             pt_cv_sse2_mm_set_epi64x_val=1],
+            [pt_cv_sse2_mm_set_epi64x=no;
+             pt_cv_sse2_mm_set_epi64x_val=0])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"])
+    AC_DEFINE_UNQUOTED([HAVE_SSE2_MM_SET_EPI64X],
+        [$pt_cv_sse2_mm_set_epi64x_val],
+        [define to 1 if the C compiler supports SSE2 _mm_set_epi64x])
+])
+
 AS_IF([test "x$pt_cv_sse2" == xdefault], [SSE2_CFLAGS=],
       [test "x$pt_cv_sse2" != xno],      [SSE2_CFLAGS="$pt_cv_sse2"],
       [SSE2_CFLAGS="not supported"])
+
+AM_CONDITIONAL([HAVE_SSE2], [test "x$pt_cv_sse2_val" = x1])
 AC_SUBST([SSE2_CFLAGS])
 
-AC_CACHE_CHECK([for SSE2 _mm_set1_epi64x],
-    [pt_cv_sse2_mm_set1_epi64x],
-    [save_CFLAGS="$CFLAGS"
-     CFLAGS="$SSE2_CFLAGS $CFLAGS"
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-#include <emmintrin.h>
-__m128i foo() {
-    __m128i vOne = _mm_set1_epi64x(1);
-    return vOne;
-}
-]])],
-        [pt_cv_sse2_mm_set1_epi64x=yes;
-         pt_cv_sse2_mm_set1_epi64x_val=1],
-        [pt_cv_sse2_mm_set1_epi64x=no;
-         pt_cv_sse2_mm_set1_epi64x_val=0])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"])
-AC_DEFINE_UNQUOTED([HAVE_SSE2_MM_SET1_EPI64X],
-    [$pt_cv_sse2_mm_set1_epi64x_val],
-    [define to 1 if the C compiler supports SSE2 _mm_set1_epi64x])
+###############################################################################
+# SSE 4.1
+###############################################################################
+AS_IF([test "x$enable_sse4_1" != "xno"], [
+    AC_CACHE_CHECK([for SSE4.1 support], [pt_cv_sse41],
+    [pt_cv_sse41=no; pt_cv_sse41_val=0
+    for flag in default -msse4.1 -msse4
+    do
+         save_CFLAGS="$CFLAGS"
+         AS_IF([test "x$flag" != xdefault], [CFLAGS="$CFLAGS $flag"])
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #include <smmintrin.h>
+    int foo() {
+        __m128i vOne = _mm_set1_epi8(1);
+        __m128i result =  _mm_max_epi8(vOne,vOne);
+        return _mm_extract_epi8(result, 0);
+    }
+    int main(void) { return foo(); }
+    ]])],
+            [pt_cv_sse41="$flag"; pt_cv_sse41_val=1])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"
+         AS_IF([test "x$pt_cv_sse41" != xno], [break])
+    done])
+    AC_DEFINE_UNQUOTED([HAVE_SSE41], [$pt_cv_sse41_val],
+        [define to 1 if the C compiler supports SSE4.1])
+    AS_IF([test "x$pt_cv_sse41_val" != x1], [
+        AS_IF([test "x$enable_sse4_1" = xyes], [
+            dnl explicitly passed --enable_sse4_1, hence error out loud and clearly
+            AC_MSG_ERROR([You explicitly requested SSE4.1 support, but SSE4.1 CFLAGS could not be found!])
+        ], [
+            enable_sse4_1="auto (no)"
+        ])
+    ])
 
-AC_CACHE_CHECK([for SSE2 _mm_set_epi64x],
-    [pt_cv_sse2_mm_set_epi64x],
-    [save_CFLAGS="$CFLAGS"
-     CFLAGS="$SSE2_CFLAGS $CFLAGS"
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-#include <emmintrin.h>
-__m128i foo() {
-    __m128i vOne = _mm_set_epi64x(1,1);
-    return vOne;
-}
-]])],
-        [pt_cv_sse2_mm_set_epi64x=yes;
-         pt_cv_sse2_mm_set_epi64x_val=1],
-        [pt_cv_sse2_mm_set_epi64x=no;
-         pt_cv_sse2_mm_set_epi64x_val=0])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"])
-AC_DEFINE_UNQUOTED([HAVE_SSE2_MM_SET_EPI64X],
-    [$pt_cv_sse2_mm_set_epi64x_val],
-    [define to 1 if the C compiler supports SSE2 _mm_set_epi64x])
+    AC_CACHE_CHECK([for SSE4.1 _mm_insert_epi64],
+        [pt_cv_sse41_mm_insert_epi64],
+        [save_CFLAGS="$CFLAGS"
+         CFLAGS="$SSE41_CFLAGS $CFLAGS"
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <smmintrin.h>
+    __m128i foo() {
+        __m128i vOne = _mm_set1_epi8(1);
+        return _mm_insert_epi64(vOne,INT64_MIN,0);
+    }
+    ]])],
+            [pt_cv_sse41_mm_insert_epi64=yes;
+             pt_cv_sse41_mm_insert_epi64_val=1],
+            [pt_cv_sse41_mm_insert_epi64=no;
+             pt_cv_sse41_mm_insert_epi64_val=0])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"])
+    AC_DEFINE_UNQUOTED([HAVE_SSE41_MM_INSERT_EPI64],
+        [$pt_cv_sse41_mm_insert_epi64_val],
+        [define to 1 if the C compiler supports SSE4.1 _mm_insert_epi64])
 
-AC_CACHE_CHECK([for SSE4.1 support], [pt_cv_sse41],
-[pt_cv_sse41=no; pt_cv_sse41_val=0
-for flag in default -msse4.1 -msse4 -march=corei7
-do
-     save_CFLAGS="$CFLAGS"
-     AS_IF([test "x$flag" != xdefault], [CFLAGS="$CFLAGS $flag"])
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_LINK_IFELSE([AC_LANG_SOURCE([[
-#include <smmintrin.h>
-int foo() {
-    __m128i vOne = _mm_set1_epi8(1);
-    __m128i result =  _mm_max_epi8(vOne,vOne);
-    return _mm_extract_epi8(result, 0);
-}
-int main(void) { return foo(); }
-]])],
-        [pt_cv_sse41="$flag"; pt_cv_sse41_val=1])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"
-     AS_IF([test "x$pt_cv_sse41" != xno], [break])
-done])
-AC_DEFINE_UNQUOTED([HAVE_SSE41], [$pt_cv_sse41_val],
-    [define to 1 if the C compiler supports SSE4.1])
+    AC_CACHE_CHECK([for SSE4.1 _mm_extract_epi64],
+        [pt_cv_sse41_mm_extract_epi64],
+        [save_CFLAGS="$CFLAGS"
+         CFLAGS="$SSE41_CFLAGS $CFLAGS"
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <immintrin.h>
+    int64_t foo() {
+        __m128i vZero = _mm_set1_epi8(0);
+        return _mm_extract_epi64(vZero,0);
+    }
+    int main(void) { return foo(); }
+    ]])],
+            [pt_cv_sse41_mm_extract_epi64=yes;
+             pt_cv_sse41_mm_extract_epi64_val=1],
+            [pt_cv_sse41_mm_extract_epi64=no;
+             pt_cv_sse41_mm_extract_epi64_val=0])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"])
+    AC_DEFINE_UNQUOTED([HAVE_SSE41_MM_EXTRACT_EPI64],
+        [$pt_cv_sse41_mm_extract_epi64_val],
+        [define to 1 if the C compiler supports SSE4.1 _mm_extract_epi64])
+])
+
 AM_CONDITIONAL([HAVE_SSE41], [test "x$pt_cv_sse41_val" = x1])
 AS_IF([test "x$pt_cv_sse41" == xdefault], [SSE41_CFLAGS=],
       [test "x$pt_cv_sse41" != xno],      [SSE41_CFLAGS="$pt_cv_sse41"],
@@ -213,510 +312,508 @@ AC_SUBST([SSE41_CFLAGS])
 
 AM_CONDITIONAL([HAVE_SSE], [test "x$pt_cv_sse2_val" = x1 || test "x$pt_cv_sse41_val" = x1])
 
-AC_CACHE_CHECK([for SSE4.1 _mm_insert_epi64],
-    [pt_cv_sse41_mm_insert_epi64],
-    [save_CFLAGS="$CFLAGS"
-     CFLAGS="$SSE41_CFLAGS $CFLAGS"
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-#include <smmintrin.h>
-__m128i foo() {
-    __m128i vOne = _mm_set1_epi8(1);
-    return _mm_insert_epi64(vOne,INT64_MIN,0);
-}
-]])],
-        [pt_cv_sse41_mm_insert_epi64=yes;
-         pt_cv_sse41_mm_insert_epi64_val=1],
-        [pt_cv_sse41_mm_insert_epi64=no;
-         pt_cv_sse41_mm_insert_epi64_val=0])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"])
-AC_DEFINE_UNQUOTED([HAVE_SSE41_MM_INSERT_EPI64],
-    [$pt_cv_sse41_mm_insert_epi64_val],
-    [define to 1 if the C compiler supports SSE4.1 _mm_insert_epi64])
-
-AC_CACHE_CHECK([for SSE4.1 _mm_extract_epi64],
-    [pt_cv_sse41_mm_extract_epi64],
-    [save_CFLAGS="$CFLAGS"
-     CFLAGS="$SSE41_CFLAGS $CFLAGS"
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_LINK_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-#include <immintrin.h>
-int64_t foo() {
-    __m128i vZero = _mm_set1_epi8(0);
-    return _mm_extract_epi64(vZero,0);
-}
-int main(void) { return foo(); }
-]])],
-        [pt_cv_sse41_mm_extract_epi64=yes;
-         pt_cv_sse41_mm_extract_epi64_val=1],
-        [pt_cv_sse41_mm_extract_epi64=no;
-         pt_cv_sse41_mm_extract_epi64_val=0])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"])
-AC_DEFINE_UNQUOTED([HAVE_SSE41_MM_EXTRACT_EPI64],
-    [$pt_cv_sse41_mm_extract_epi64_val],
-    [define to 1 if the C compiler supports SSE4.1 _mm_extract_epi64])
-
-AC_CACHE_CHECK([for AVX2 support], [pt_cv_avx2],
-[pt_cv_avx2=no; pt_cv_avx2_val=0
-for flag in default -mavx2 -march=core-avx2
-do
-     save_CFLAGS="$CFLAGS"
-     AS_IF([test "x$flag" != xdefault], [CFLAGS="$CFLAGS $flag"])
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_LINK_IFELSE([AC_LANG_SOURCE([[
-#include <immintrin.h>
-void parasail_memset___m256i(__m256i *b, __m256i c, size_t len)
-{
-    size_t i;
-    for (i=0; i<len; ++i) {
-        _mm256_store_si256(&b[i], c);
+###############################################################################
+# AVX2
+###############################################################################
+AS_IF([test "x$enable_avx2" != "xno"], [
+    AC_CACHE_CHECK([for AVX2 support], [pt_cv_avx2],
+    [pt_cv_avx2=no; pt_cv_avx2_val=0
+    for flag in default -mavx2
+    do
+         save_CFLAGS="$CFLAGS"
+         AS_IF([test "x$flag" != xdefault], [CFLAGS="$CFLAGS $flag"])
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #include <immintrin.h>
+    void parasail_memset___m256i(__m256i *b, __m256i c, size_t len)
+    {
+        size_t i;
+        for (i=0; i<len; ++i) {
+            _mm256_store_si256(&b[i], c);
+        }
     }
-}
 
-int foo() {
-    __m256i vOne = _mm256_set1_epi8(1);
-    __m256i result =  _mm256_add_epi8(vOne,vOne);
-    return _mm_extract_epi16(_mm256_extracti128_si256(result,0),0);
-}
-int main(void) { return foo(); }
-]])],
-        [pt_cv_avx2="$flag"; pt_cv_avx2_val=1])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"
-     AS_IF([test "x$pt_cv_avx2" != xno], [break])
-done])
-AC_DEFINE_UNQUOTED([HAVE_AVX2], [$pt_cv_avx2_val],
-    [define to 1 if the C compiler supports AVX2])
+    int foo() {
+        __m256i vOne = _mm256_set1_epi8(1);
+        __m256i result =  _mm256_add_epi8(vOne,vOne);
+        return _mm_extract_epi16(_mm256_extracti128_si256(result,0),0);
+    }
+    int main(void) { return foo(); }
+    ]])],
+            [pt_cv_avx2="$flag"; pt_cv_avx2_val=1])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"
+         AS_IF([test "x$pt_cv_avx2" != xno], [break])
+    done])
+    AC_DEFINE_UNQUOTED([HAVE_AVX2], [$pt_cv_avx2_val],
+        [define to 1 if the C compiler supports AVX2])
+    AS_IF([test "x$pt_cv_avx2_val" != x1], [
+        AS_IF([test "x$enable_avx2" = xyes], [
+            dnl explicitly passed --enable_avx2, hence error out loud and clearly
+            AC_MSG_ERROR([You explicitly requested AVX2 support, but AVX2 CFLAGS could not be found!])
+        ], [
+            enable_avx2="auto (no)"
+        ])
+    ])
+
+    AC_CACHE_CHECK([for AVX2 _mm256_set1_epi64x],
+        [pt_cv_avx2_mm256_set1_epi64x],
+        [save_CFLAGS="$CFLAGS"
+         CFLAGS="$AVX2_CFLAGS $CFLAGS"
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <immintrin.h>
+    __m256i foo() {
+        __m256i vOne = _mm256_set1_epi64x(1);
+        return vOne;
+    }
+    ]])],
+            [pt_cv_avx2_mm256_set1_epi64x=yes;
+             pt_cv_avx2_mm256_set1_epi64x_val=1],
+            [pt_cv_avx2_mm256_set1_epi64x=no;
+             pt_cv_avx2_mm256_set1_epi64x_val=0])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"])
+    AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_SET1_EPI64X],
+        [$pt_cv_avx2_mm256_set1_epi64x_val],
+        [define to 1 if the C compiler supports AVX2 _mm256_set1_epi64x])
+
+    AC_CACHE_CHECK([for AVX2 _mm256_set_epi64x],
+        [pt_cv_avx2_mm256_set_epi64x],
+        [save_CFLAGS="$CFLAGS"
+         CFLAGS="$AVX2_CFLAGS $CFLAGS"
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <immintrin.h>
+    __m256i foo() {
+        __m256i vOne = _mm256_set_epi64x(1,1,1,1);
+        return vOne;
+    }
+    ]])],
+            [pt_cv_avx2_mm256_set_epi64x=yes;
+             pt_cv_avx2_mm256_set_epi64x_val=1],
+            [pt_cv_avx2_mm256_set_epi64x=no;
+             pt_cv_avx2_mm256_set_epi64x_val=0])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"])
+    AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_SET_EPI64X],
+        [$pt_cv_avx2_mm256_set_epi64x_val],
+        [define to 1 if the C compiler supports AVX2 _mm256_set_epi64x])
+
+    AC_CACHE_CHECK([for AVX2 _mm256_insert_epi64],
+        [pt_cv_avx2_mm256_insert_epi64],
+        [save_CFLAGS="$CFLAGS"
+         CFLAGS="$AVX2_CFLAGS $CFLAGS"
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <immintrin.h>
+    __m256i foo() {
+        __m256i vOne = _mm256_set1_epi8(1);
+        return _mm256_insert_epi64(vOne,INT64_MIN,0);
+    }
+    ]])],
+            [pt_cv_avx2_mm256_insert_epi64=yes;
+             pt_cv_avx2_mm256_insert_epi64_val=1],
+            [pt_cv_avx2_mm256_insert_epi64=no;
+             pt_cv_avx2_mm256_insert_epi64_val=0])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"])
+    AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_INSERT_EPI64],
+        [$pt_cv_avx2_mm256_insert_epi64_val],
+        [define to 1 if the C compiler supports AVX2 _mm256_insert_epi64])
+
+    AC_CACHE_CHECK([for AVX2 _mm256_insert_epi32],
+        [pt_cv_avx2_mm256_insert_epi32],
+        [save_CFLAGS="$CFLAGS"
+         CFLAGS="$AVX2_CFLAGS $CFLAGS"
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <immintrin.h>
+    __m256i foo() {
+        __m256i vOne = _mm256_set1_epi8(1);
+        return _mm256_insert_epi32(vOne,INT32_MIN,0);
+    }
+    ]])],
+            [pt_cv_avx2_mm256_insert_epi32=yes;
+             pt_cv_avx2_mm256_insert_epi32_val=1],
+            [pt_cv_avx2_mm256_insert_epi32=no;
+             pt_cv_avx2_mm256_insert_epi32_val=0])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"])
+    AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_INSERT_EPI32],
+        [$pt_cv_avx2_mm256_insert_epi32_val],
+        [define to 1 if the C compiler supports AVX2 _mm256_insert_epi32])
+
+    AC_CACHE_CHECK([for AVX2 _mm256_insert_epi16],
+        [pt_cv_avx2_mm256_insert_epi16],
+        [save_CFLAGS="$CFLAGS"
+         CFLAGS="$AVX2_CFLAGS $CFLAGS"
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <immintrin.h>
+    __m256i foo() {
+        __m256i vZero = _mm256_set1_epi8(0);
+        return _mm256_insert_epi16(vZero,INT16_MIN,0);
+    }
+    ]])],
+            [pt_cv_avx2_mm256_insert_epi16=yes;
+             pt_cv_avx2_mm256_insert_epi16_val=1],
+            [pt_cv_avx2_mm256_insert_epi16=no;
+             pt_cv_avx2_mm256_insert_epi16_val=0])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"])
+    AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_INSERT_EPI16],
+        [$pt_cv_avx2_mm256_insert_epi16_val],
+        [define to 1 if the C compiler supports AVX2 _mm256_insert_epi16])
+
+    AC_CACHE_CHECK([for AVX2 _mm256_insert_epi8],
+        [pt_cv_avx2_mm256_insert_epi8],
+        [save_CFLAGS="$CFLAGS"
+         CFLAGS="$AVX2_CFLAGS $CFLAGS"
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <immintrin.h>
+    __m256i foo() {
+        __m256i vZero = _mm256_set1_epi8(0);
+        return _mm256_insert_epi8(vZero,INT8_MIN,0);
+    }
+    ]])],
+            [pt_cv_avx2_mm256_insert_epi8=yes;
+             pt_cv_avx2_mm256_insert_epi8_val=1],
+            [pt_cv_avx2_mm256_insert_epi8=no;
+             pt_cv_avx2_mm256_insert_epi8_val=0])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"])
+    AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_INSERT_EPI8],
+        [$pt_cv_avx2_mm256_insert_epi8_val],
+        [define to 1 if the C compiler supports AVX2 _mm256_insert_epi8])
+
+    AC_CACHE_CHECK([for AVX2 _mm256_extract_epi64],
+        [pt_cv_avx2_mm256_extract_epi64],
+        [save_CFLAGS="$CFLAGS"
+         CFLAGS="$AVX2_CFLAGS $CFLAGS"
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <immintrin.h>
+    int64_t foo() {
+        __m256i vZero = _mm256_set1_epi8(0);
+        return _mm256_extract_epi64(vZero,0);
+    }
+    int main(void) { return foo(); }
+    ]])],
+            [pt_cv_avx2_mm256_extract_epi64=yes;
+             pt_cv_avx2_mm256_extract_epi64_val=1],
+            [pt_cv_avx2_mm256_extract_epi64=no;
+             pt_cv_avx2_mm256_extract_epi64_val=0])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"])
+    AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_EXTRACT_EPI64],
+        [$pt_cv_avx2_mm256_extract_epi64_val],
+        [define to 1 if the C compiler supports AVX2 _mm256_extract_epi64])
+
+    AC_CACHE_CHECK([for AVX2 _mm256_extract_epi32],
+        [pt_cv_avx2_mm256_extract_epi32],
+        [save_CFLAGS="$CFLAGS"
+         CFLAGS="$AVX2_CFLAGS $CFLAGS"
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <immintrin.h>
+    int32_t foo() {
+        __m256i vZero = _mm256_set1_epi8(0);
+        return _mm256_extract_epi32(vZero,0);
+    }
+    int main(void) { return foo(); }
+    ]])],
+            [pt_cv_avx2_mm256_extract_epi32=yes;
+             pt_cv_avx2_mm256_extract_epi32_val=1],
+            [pt_cv_avx2_mm256_extract_epi32=no;
+             pt_cv_avx2_mm256_extract_epi32_val=0])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"])
+    AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_EXTRACT_EPI32],
+        [$pt_cv_avx2_mm256_extract_epi32_val],
+        [define to 1 if the C compiler supports AVX2 _mm256_extract_epi32])
+
+    AC_CACHE_CHECK([for AVX2 _mm256_extract_epi16],
+        [pt_cv_avx2_mm256_extract_epi16],
+        [save_CFLAGS="$CFLAGS"
+         CFLAGS="$AVX2_CFLAGS $CFLAGS"
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <immintrin.h>
+    int16_t foo() {
+        __m256i vZero = _mm256_set1_epi8(0);
+        return _mm256_extract_epi16(vZero,0);
+    }
+    int main(void) { return foo(); }
+    ]])],
+            [pt_cv_avx2_mm256_extract_epi16=yes;
+             pt_cv_avx2_mm256_extract_epi16_val=1],
+            [pt_cv_avx2_mm256_extract_epi16=no;
+             pt_cv_avx2_mm256_extract_epi16_val=0])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"])
+    AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_EXTRACT_EPI16],
+        [$pt_cv_avx2_mm256_extract_epi16_val],
+        [define to 1 if the C compiler supports AVX2 _mm256_extract_epi16])
+
+    AC_CACHE_CHECK([for AVX2 _mm256_extract_epi8],
+        [pt_cv_avx2_mm256_extract_epi8],
+        [save_CFLAGS="$CFLAGS"
+         CFLAGS="$AVX2_CFLAGS $CFLAGS"
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    #include <immintrin.h>
+    int8_t foo() {
+        __m256i vZero = _mm256_set1_epi8(0);
+        return _mm256_extract_epi8(vZero,0);
+    }
+    int main(void) { return foo(); }
+    ]])],
+            [pt_cv_avx2_mm256_extract_epi8=yes;
+             pt_cv_avx2_mm256_extract_epi8_val=1],
+            [pt_cv_avx2_mm256_extract_epi8=no;
+             pt_cv_avx2_mm256_extract_epi8_val=0])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"])
+    AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_EXTRACT_EPI8],
+        [$pt_cv_avx2_mm256_extract_epi8_val],
+        [define to 1 if the C compiler supports AVX2 _mm256_extract_epi8])
+])
+
 AM_CONDITIONAL([HAVE_AVX2], [test "x$pt_cv_avx2_val" = x1])
 AS_IF([test "x$pt_cv_avx2" == xdefault], [AVX2_CFLAGS=],
       [test "x$pt_cv_avx2" != xno],      [AVX2_CFLAGS="$pt_cv_avx2"],
       [AVX2_CFLAGS="not supported"])
 AC_SUBST([AVX2_CFLAGS])
 
-AC_CACHE_CHECK([for AVX2 _mm256_set1_epi64x],
-    [pt_cv_avx2_mm256_set1_epi64x],
-    [save_CFLAGS="$CFLAGS"
-     CFLAGS="$AVX2_CFLAGS $CFLAGS"
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-#include <immintrin.h>
-__m256i foo() {
-    __m256i vOne = _mm256_set1_epi64x(1);
-    return vOne;
-}
-]])],
-        [pt_cv_avx2_mm256_set1_epi64x=yes;
-         pt_cv_avx2_mm256_set1_epi64x_val=1],
-        [pt_cv_avx2_mm256_set1_epi64x=no;
-         pt_cv_avx2_mm256_set1_epi64x_val=0])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"])
-AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_SET1_EPI64X],
-    [$pt_cv_avx2_mm256_set1_epi64x_val],
-    [define to 1 if the C compiler supports AVX2 _mm256_set1_epi64x])
-
-AC_CACHE_CHECK([for AVX2 _mm256_set_epi64x],
-    [pt_cv_avx2_mm256_set_epi64x],
-    [save_CFLAGS="$CFLAGS"
-     CFLAGS="$AVX2_CFLAGS $CFLAGS"
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-#include <immintrin.h>
-__m256i foo() {
-    __m256i vOne = _mm256_set_epi64x(1,1,1,1);
-    return vOne;
-}
-]])],
-        [pt_cv_avx2_mm256_set_epi64x=yes;
-         pt_cv_avx2_mm256_set_epi64x_val=1],
-        [pt_cv_avx2_mm256_set_epi64x=no;
-         pt_cv_avx2_mm256_set_epi64x_val=0])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"])
-AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_SET_EPI64X],
-    [$pt_cv_avx2_mm256_set_epi64x_val],
-    [define to 1 if the C compiler supports AVX2 _mm256_set_epi64x])
-
-AC_CACHE_CHECK([for AVX2 _mm256_insert_epi64],
-    [pt_cv_avx2_mm256_insert_epi64],
-    [save_CFLAGS="$CFLAGS"
-     CFLAGS="$AVX2_CFLAGS $CFLAGS"
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-#include <immintrin.h>
-__m256i foo() {
-    __m256i vOne = _mm256_set1_epi8(1);
-    return _mm256_insert_epi64(vOne,INT64_MIN,0);
-}
-]])],
-        [pt_cv_avx2_mm256_insert_epi64=yes;
-         pt_cv_avx2_mm256_insert_epi64_val=1],
-        [pt_cv_avx2_mm256_insert_epi64=no;
-         pt_cv_avx2_mm256_insert_epi64_val=0])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"])
-AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_INSERT_EPI64],
-    [$pt_cv_avx2_mm256_insert_epi64_val],
-    [define to 1 if the C compiler supports AVX2 _mm256_insert_epi64])
-
-AC_CACHE_CHECK([for AVX2 _mm256_insert_epi32],
-    [pt_cv_avx2_mm256_insert_epi32],
-    [save_CFLAGS="$CFLAGS"
-     CFLAGS="$AVX2_CFLAGS $CFLAGS"
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-#include <immintrin.h>
-__m256i foo() {
-    __m256i vOne = _mm256_set1_epi8(1);
-    return _mm256_insert_epi32(vOne,INT32_MIN,0);
-}
-]])],
-        [pt_cv_avx2_mm256_insert_epi32=yes;
-         pt_cv_avx2_mm256_insert_epi32_val=1],
-        [pt_cv_avx2_mm256_insert_epi32=no;
-         pt_cv_avx2_mm256_insert_epi32_val=0])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"])
-AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_INSERT_EPI32],
-    [$pt_cv_avx2_mm256_insert_epi32_val],
-    [define to 1 if the C compiler supports AVX2 _mm256_insert_epi32])
-
-AC_CACHE_CHECK([for AVX2 _mm256_insert_epi16],
-    [pt_cv_avx2_mm256_insert_epi16],
-    [save_CFLAGS="$CFLAGS"
-     CFLAGS="$AVX2_CFLAGS $CFLAGS"
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-#include <immintrin.h>
-__m256i foo() {
-    __m256i vZero = _mm256_set1_epi8(0);
-    return _mm256_insert_epi16(vZero,INT16_MIN,0);
-}
-]])],
-        [pt_cv_avx2_mm256_insert_epi16=yes;
-         pt_cv_avx2_mm256_insert_epi16_val=1],
-        [pt_cv_avx2_mm256_insert_epi16=no;
-         pt_cv_avx2_mm256_insert_epi16_val=0])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"])
-AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_INSERT_EPI16],
-    [$pt_cv_avx2_mm256_insert_epi16_val],
-    [define to 1 if the C compiler supports AVX2 _mm256_insert_epi16])
-
-AC_CACHE_CHECK([for AVX2 _mm256_insert_epi8],
-    [pt_cv_avx2_mm256_insert_epi8],
-    [save_CFLAGS="$CFLAGS"
-     CFLAGS="$AVX2_CFLAGS $CFLAGS"
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-#include <immintrin.h>
-__m256i foo() {
-    __m256i vZero = _mm256_set1_epi8(0);
-    return _mm256_insert_epi8(vZero,INT8_MIN,0);
-}
-]])],
-        [pt_cv_avx2_mm256_insert_epi8=yes;
-         pt_cv_avx2_mm256_insert_epi8_val=1],
-        [pt_cv_avx2_mm256_insert_epi8=no;
-         pt_cv_avx2_mm256_insert_epi8_val=0])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"])
-AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_INSERT_EPI8],
-    [$pt_cv_avx2_mm256_insert_epi8_val],
-    [define to 1 if the C compiler supports AVX2 _mm256_insert_epi8])
-
-AC_CACHE_CHECK([for AVX2 _mm256_extract_epi64],
-    [pt_cv_avx2_mm256_extract_epi64],
-    [save_CFLAGS="$CFLAGS"
-     CFLAGS="$AVX2_CFLAGS $CFLAGS"
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_LINK_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-#include <immintrin.h>
-int64_t foo() {
-    __m256i vZero = _mm256_set1_epi8(0);
-    return _mm256_extract_epi64(vZero,0);
-}
-int main(void) { return foo(); }
-]])],
-        [pt_cv_avx2_mm256_extract_epi64=yes;
-         pt_cv_avx2_mm256_extract_epi64_val=1],
-        [pt_cv_avx2_mm256_extract_epi64=no;
-         pt_cv_avx2_mm256_extract_epi64_val=0])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"])
-AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_EXTRACT_EPI64],
-    [$pt_cv_avx2_mm256_extract_epi64_val],
-    [define to 1 if the C compiler supports AVX2 _mm256_extract_epi64])
-
-AC_CACHE_CHECK([for AVX2 _mm256_extract_epi32],
-    [pt_cv_avx2_mm256_extract_epi32],
-    [save_CFLAGS="$CFLAGS"
-     CFLAGS="$AVX2_CFLAGS $CFLAGS"
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_LINK_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-#include <immintrin.h>
-int32_t foo() {
-    __m256i vZero = _mm256_set1_epi8(0);
-    return _mm256_extract_epi32(vZero,0);
-}
-int main(void) { return foo(); }
-]])],
-        [pt_cv_avx2_mm256_extract_epi32=yes;
-         pt_cv_avx2_mm256_extract_epi32_val=1],
-        [pt_cv_avx2_mm256_extract_epi32=no;
-         pt_cv_avx2_mm256_extract_epi32_val=0])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"])
-AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_EXTRACT_EPI32],
-    [$pt_cv_avx2_mm256_extract_epi32_val],
-    [define to 1 if the C compiler supports AVX2 _mm256_extract_epi32])
-
-AC_CACHE_CHECK([for AVX2 _mm256_extract_epi16],
-    [pt_cv_avx2_mm256_extract_epi16],
-    [save_CFLAGS="$CFLAGS"
-     CFLAGS="$AVX2_CFLAGS $CFLAGS"
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_LINK_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-#include <immintrin.h>
-int16_t foo() {
-    __m256i vZero = _mm256_set1_epi8(0);
-    return _mm256_extract_epi16(vZero,0);
-}
-int main(void) { return foo(); }
-]])],
-        [pt_cv_avx2_mm256_extract_epi16=yes;
-         pt_cv_avx2_mm256_extract_epi16_val=1],
-        [pt_cv_avx2_mm256_extract_epi16=no;
-         pt_cv_avx2_mm256_extract_epi16_val=0])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"])
-AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_EXTRACT_EPI16],
-    [$pt_cv_avx2_mm256_extract_epi16_val],
-    [define to 1 if the C compiler supports AVX2 _mm256_extract_epi16])
-
-AC_CACHE_CHECK([for AVX2 _mm256_extract_epi8],
-    [pt_cv_avx2_mm256_extract_epi8],
-    [save_CFLAGS="$CFLAGS"
-     CFLAGS="$AVX2_CFLAGS $CFLAGS"
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_LINK_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-#include <immintrin.h>
-int8_t foo() {
-    __m256i vZero = _mm256_set1_epi8(0);
-    return _mm256_extract_epi8(vZero,0);
-}
-int main(void) { return foo(); }
-]])],
-        [pt_cv_avx2_mm256_extract_epi8=yes;
-         pt_cv_avx2_mm256_extract_epi8_val=1],
-        [pt_cv_avx2_mm256_extract_epi8=no;
-         pt_cv_avx2_mm256_extract_epi8_val=0])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"])
-AC_DEFINE_UNQUOTED([HAVE_AVX2_MM256_EXTRACT_EPI8],
-    [$pt_cv_avx2_mm256_extract_epi8_val],
-    [define to 1 if the C compiler supports AVX2 _mm256_extract_epi8])
-
-AC_CACHE_CHECK([for AVX512F support], [pt_cv_avx512f],
-[pt_cv_avx512f=no; pt_cv_avx512f_val=0
-for flag in default -mavx512f -xMIC-AVX512 -march=knl
-do
-     save_CFLAGS="$CFLAGS"
-     AS_IF([test "x$flag" != xdefault], [CFLAGS="$CFLAGS $flag"])
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_LINK_IFELSE([AC_LANG_SOURCE([[
-#include <immintrin.h>
-void parasail_memset___m512i(__m512i *b, __m512i c, size_t len)
-{
-    size_t i;
-    for (i=0; i<len; ++i) {
-        _mm512_store_si512(&b[i], c);
+###############################################################################
+# AVX512
+###############################################################################
+AS_IF([test "x$enable_avx512" != "xno"], [
+    AC_CACHE_CHECK([for AVX512F support], [pt_cv_avx512f],
+    [pt_cv_avx512f=no; pt_cv_avx512f_val=0
+    for flag in default -mavx512f -xMIC-AVX512
+    do
+         save_CFLAGS="$CFLAGS"
+         AS_IF([test "x$flag" != xdefault], [CFLAGS="$CFLAGS $flag"])
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #include <immintrin.h>
+    void parasail_memset___m512i(__m512i *b, __m512i c, size_t len)
+    {
+        size_t i;
+        for (i=0; i<len; ++i) {
+            _mm512_store_si512(&b[i], c);
+        }
     }
-}
 
-int foo() {
-    __m512i vOne = _mm512_set1_epi32(1);
-    __m512i result =  _mm512_add_epi32(vOne,vOne);
-    return 0;
-}
-int main(void) { return foo(); }
-]])],
-        [pt_cv_avx512f="$flag"; pt_cv_avx512f_val=1])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"
-     AS_IF([test "x$pt_cv_avx512f" != xno], [break])
-done])
-AC_DEFINE_UNQUOTED([HAVE_AVX512F], [$pt_cv_avx512f_val],
-    [define to 1 if the C compiler supports AVX512F])
+    int foo() {
+        __m512i vOne = _mm512_set1_epi32(1);
+        __m512i result =  _mm512_add_epi32(vOne,vOne);
+        return 0;
+    }
+    int main(void) { return foo(); }
+    ]])],
+            [pt_cv_avx512f="$flag"; pt_cv_avx512f_val=1])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"
+         AS_IF([test "x$pt_cv_avx512f" != xno], [break])
+    done])
+    AC_DEFINE_UNQUOTED([HAVE_AVX512F], [$pt_cv_avx512f_val],
+        [define to 1 if the C compiler supports AVX512F])
+    AS_IF([test "x$pt_cv_avx512f_val" != x1], [
+        AS_IF([test "x$enable_avx512" = xyes], [
+            dnl explicitly passed --enable_avx512, hence error out loud and clearly
+            AC_MSG_ERROR([You explicitly requested AVX512 support, but AVX512 CFLAGS could not be found!])
+        ], [
+            enable_avx512="auto (no)"
+        ])
+    ])
+
+    AC_CACHE_CHECK([for AVX512BW support], [pt_cv_avx512bw],
+    [pt_cv_avx512bw=no; pt_cv_avx512bw_val=0
+    for flag in default -mavx512bw -xCORE-AVX512
+    do
+         save_CFLAGS="$CFLAGS"
+         AS_IF([test "x$flag" != xdefault], [CFLAGS="$CFLAGS $flag"])
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #include <immintrin.h>
+    void parasail_memset___m512i(__m512i *b, __m512i c, size_t len)
+    {
+        size_t i;
+        for (i=0; i<len; ++i) {
+            _mm512_store_si512(&b[i], c);
+        }
+    }
+
+    int foo() {
+        __m512i vOne = _mm512_set1_epi8(1);
+        __m512i result =  _mm512_add_epi8(vOne,vOne);
+        return 0;
+    }
+    int main(void) { return foo(); }
+    ]])],
+            [pt_cv_avx512bw="$flag"; pt_cv_avx512bw_val=1])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"
+         AS_IF([test "x$pt_cv_avx512bw" != xno], [break])
+    done])
+    AC_DEFINE_UNQUOTED([HAVE_AVX512BW], [$pt_cv_avx512bw_val],
+        [define to 1 if the C compiler supports AVX512BW])
+
+    AC_CACHE_CHECK([for AVX512VBMI support], [pt_cv_avx512vbmi],
+    [pt_cv_avx512vbmi=no; pt_cv_avx512vbmi_val=0
+    for flag in default -mavx512vbmi -xCORE-AVX512
+    do
+         save_CFLAGS="$CFLAGS"
+         AS_IF([test "x$flag" != xdefault], [CFLAGS="$CFLAGS $flag"])
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #include <immintrin.h>
+    void parasail_memset___m512i(__m512i *b, __m512i c, size_t len)
+    {
+        size_t i;
+        for (i=0; i<len; ++i) {
+            _mm512_store_si512(&b[i], c);
+        }
+    }
+
+    int foo() {
+        __m512i vOne = _mm512_set1_epi8(1);
+        __m512i result =  _mm512_permutex2var_epi8(vOne,vOne,vOne);
+        return 0;
+    }
+    int main(void) { return foo(); }
+    ]])],
+            [pt_cv_avx512vbmi="$flag"; pt_cv_avx512vbmi_val=1])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"
+         AS_IF([test "x$pt_cv_avx512vbmi" != xno], [break])
+    done])
+    AC_DEFINE_UNQUOTED([HAVE_AVX512VBMI], [$pt_cv_avx512vbmi_val],
+        [define to 1 if the C compiler supports AVX512VBMI])
+
+    AC_CACHE_CHECK([for xgetbv],
+        [pt_cv_xgetbv],
+        [AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    #include <stdint.h>
+    int check_xcr0_ymm()
+    {
+        uint32_t xcr0;
+    #if defined(_MSC_VER)
+        xcr0 = (uint32_t)_xgetbv(0);  /* min VS2010 SP1 compiler is required */
+    #else
+        __asm__ ("xgetbv" : "=a" (xcr0) : "c" (0) : "%edx" );
+    #endif
+        return ((xcr0 & 6) == 6); /* checking if xmm and ymm state are enabled in XCR0 */
+    }
+    ]])],
+            [pt_cv_xgetbv=yes; pt_cv_xgetbv_val=1],
+            [pt_cv_xgetbv=no; pt_cv_xgetbv_val=0])])
+    AC_DEFINE_UNQUOTED([HAVE_XGETBV], [$pt_cv_xgetbv_val],
+        [define to 1 if the C compiler supports xgetbv])
+])
+
 AM_CONDITIONAL([HAVE_AVX512F], [test "x$pt_cv_avx512f_val" = x1])
 AS_IF([test "x$pt_cv_avx512f" == xdefault], [AVX512F_CFLAGS=],
       [test "x$pt_cv_avx512f" != xno],      [AVX512F_CFLAGS="$pt_cv_avx512f"],
       [AVX512F_CFLAGS="not supported"])
 AC_SUBST([AVX512F_CFLAGS])
 
-AC_CACHE_CHECK([for AVX512BW support], [pt_cv_avx512bw],
-[pt_cv_avx512bw=no; pt_cv_avx512bw_val=0
-for flag in default -mavx512bw -xCORE-AVX512 -march=skylake-avx512
-do
-     save_CFLAGS="$CFLAGS"
-     AS_IF([test "x$flag" != xdefault], [CFLAGS="$CFLAGS $flag"])
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_LINK_IFELSE([AC_LANG_SOURCE([[
-#include <immintrin.h>
-void parasail_memset___m512i(__m512i *b, __m512i c, size_t len)
-{
-    size_t i;
-    for (i=0; i<len; ++i) {
-        _mm512_store_si512(&b[i], c);
-    }
-}
-
-int foo() {
-    __m512i vOne = _mm512_set1_epi8(1);
-    __m512i result =  _mm512_add_epi8(vOne,vOne);
-    return 0;
-}
-int main(void) { return foo(); }
-]])],
-        [pt_cv_avx512bw="$flag"; pt_cv_avx512bw_val=1])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"
-     AS_IF([test "x$pt_cv_avx512bw" != xno], [break])
-done])
-AC_DEFINE_UNQUOTED([HAVE_AVX512BW], [$pt_cv_avx512bw_val],
-    [define to 1 if the C compiler supports AVX512BW])
 AM_CONDITIONAL([HAVE_AVX512bw], [test "x$pt_cv_avx512bw_val" = x1])
 AS_IF([test "x$pt_cv_avx512bw" == xdefault], [AVX512BW_CFLAGS=],
       [test "x$pt_cv_avx512bw" != xno],      [AVX512BW_CFLAGS="$pt_cv_avx512bw"],
       [AVX512BW_CFLAGS="not supported"])
 AC_SUBST([AVX512BW_CFLAGS])
 
-AC_CACHE_CHECK([for AVX512VBMI support], [pt_cv_avx512vbmi],
-[pt_cv_avx512vbmi=no; pt_cv_avx512vbmi_val=0
-for flag in default -mavx512vbmi -xCORE-AVX512 -march=skylake-avx512
-do
-     save_CFLAGS="$CFLAGS"
-     AS_IF([test "x$flag" != xdefault], [CFLAGS="$CFLAGS $flag"])
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_LINK_IFELSE([AC_LANG_SOURCE([[
-#include <immintrin.h>
-void parasail_memset___m512i(__m512i *b, __m512i c, size_t len)
-{
-    size_t i;
-    for (i=0; i<len; ++i) {
-        _mm512_store_si512(&b[i], c);
-    }
-}
-
-int foo() {
-    __m512i vOne = _mm512_set1_epi8(1);
-    __m512i result =  _mm512_permutex2var_epi8(vOne,vOne,vOne);
-    return 0;
-}
-int main(void) { return foo(); }
-]])],
-        [pt_cv_avx512vbmi="$flag"; pt_cv_avx512vbmi_val=1])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"
-     AS_IF([test "x$pt_cv_avx512vbmi" != xno], [break])
-done])
-AC_DEFINE_UNQUOTED([HAVE_AVX512VBMI], [$pt_cv_avx512vbmi_val],
-    [define to 1 if the C compiler supports AVX512VBMI])
 AM_CONDITIONAL([HAVE_AVX512vbmi], [test "x$pt_cv_avx512vbmi_val" = x1])
 AS_IF([test "x$pt_cv_avx512vbmi" == xdefault], [AVX512VBMI_CFLAGS=],
       [test "x$pt_cv_avx512vbmi" != xno],      [AVX512VBMI_CFLAGS="$pt_cv_avx512vbmi"],
       [AVX512VBMI_CFLAGS="not supported"])
 AC_SUBST([AVX512VBMI_CFLAGS])
 
-AC_CACHE_CHECK([for xgetbv],
-    [pt_cv_xgetbv],
-    [AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-#include <stdint.h>
-int check_xcr0_ymm()
-{
-    uint32_t xcr0;
-#if defined(_MSC_VER)
-    xcr0 = (uint32_t)_xgetbv(0);  /* min VS2010 SP1 compiler is required */
-#else
-    __asm__ ("xgetbv" : "=a" (xcr0) : "c" (0) : "%edx" );
-#endif
-    return ((xcr0 & 6) == 6); /* checking if xmm and ymm state are enabled in XCR0 */
-}
-]])],
-        [pt_cv_xgetbv=yes; pt_cv_xgetbv_val=1],
-        [pt_cv_xgetbv=no; pt_cv_xgetbv_val=0])])
-AC_DEFINE_UNQUOTED([HAVE_XGETBV], [$pt_cv_xgetbv_val],
-    [define to 1 if the C compiler supports xgetbv])
 AM_CONDITIONAL([HAVE_XGETBV], [test "x$pt_cv_xgetbv" = xyes])
 
-AC_CACHE_CHECK([for AltiVec support], [pt_cv_altivec],
-[pt_cv_altivec=no; pt_cv_altivec_val=0
-for flag in default -maltivec -faltivec
-do 
-     save_CFLAGS="$CFLAGS"
-     AS_IF([test "x$flag" != xdefault], [CFLAGS="$CFLAGS $flag"])
-     psl_save_c_werror_flag=$ac_c_werror_flag
-     ac_c_werror_flag=yes
-     AC_LINK_IFELSE([AC_LANG_SOURCE([[
-#include <altivec.h>
-vector signed int vec_2sComp (vector signed int x)
-{
-    vector signed int one = (vector signed int) (1);
-    x = vec_nor (x, x);
-    x = vec_add (x, one);
-    return x;
-}
-int main(void)
-{
-    vector signed int two = (vector signed int) (2);
-    vector signed int result = vec_2sComp(two);
-    return vec_extract(two,0);
-}
-]])],
-        [pt_cv_altivec="$flag"; pt_cv_altivec_val=1])
-     ac_c_werror_flag=$psl_save_c_werror_flag
-     CFLAGS="$save_CFLAGS"
-     AS_IF([test "x$pt_cv_altivec" != xno], [break])
-done])
-AC_DEFINE_UNQUOTED([HAVE_ALTIVEC], [$pt_cv_altivec_val],
-    [define to 1 if the C compiler supports ALTIVEC])
+###############################################################################
+# Altivec
+###############################################################################
+AS_IF([test "x$enable_altivec" != "xno"], [
+    AC_CACHE_CHECK([for AltiVec support], [pt_cv_altivec],
+    [pt_cv_altivec=no; pt_cv_altivec_val=0
+    for flag in default -maltivec -faltivec
+    do
+         save_CFLAGS="$CFLAGS"
+         AS_IF([test "x$flag" != xdefault], [CFLAGS="$CFLAGS $flag"])
+         psl_save_c_werror_flag=$ac_c_werror_flag
+         ac_c_werror_flag=yes
+         AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #include <altivec.h>
+    vector signed int vec_2sComp (vector signed int x)
+    {
+        vector signed int one = (vector signed int) (1);
+        x = vec_nor (x, x);
+        x = vec_add (x, one);
+        return x;
+    }
+    int main(void)
+    {
+        vector signed int two = (vector signed int) (2);
+        vector signed int result = vec_2sComp(two);
+        return vec_extract(two,0);
+    }
+    ]])],
+            [pt_cv_altivec="$flag"; pt_cv_altivec_val=1])
+         ac_c_werror_flag=$psl_save_c_werror_flag
+         CFLAGS="$save_CFLAGS"
+         AS_IF([test "x$pt_cv_altivec" != xno], [break])
+    done])
+    AC_DEFINE_UNQUOTED([HAVE_ALTIVEC], [$pt_cv_altivec_val],
+        [define to 1 if the C compiler supports ALTIVEC])
+    AS_IF([test "x$pt_cv_altivec_val" != x1], [
+        AS_IF([test "x$enable_altivec" = xyes], [
+            dnl explicitly passed --enable_altivec, hence error out loud and clearly
+            AC_MSG_ERROR([You explicitly requested Altivec support, but Altivec CFLAGS could not be found!])
+        ], [
+            enable_altivec="auto (no)"
+        ])
+    ])
+])
+
 AM_CONDITIONAL([HAVE_ALTIVEC], [test "x$pt_cv_altivec_val" = x1])
 AS_IF([test "x$pt_cv_altivec" == xdefault], [ALTIVEC_CFLAGS=],
       [test "x$pt_cv_altivec" != xno],      [ALTIVEC_CFLAGS="$pt_cv_altivec"],
       [ALTIVEC_CFLAGS="not supported"])
 AC_SUBST([ALTIVEC_CFLAGS])
 
-# Checks for library functions.
+###############################################################################
+# Checks for library functions
+###############################################################################
 AC_CHECK_FUNCS([_aligned_malloc])
 AC_CHECK_FUNCS([aligned_alloc])
 AC_CHECK_FUNCS([memalign])
@@ -827,6 +924,8 @@ AC_MSG_NOTICE
 AC_LANG_PUSH([C++])
 
 AC_PROG_CXX
+AX_COMPILER_VENDOR
+AX_COMPILER_VERSION
 
 # Checks for libraries.
 
@@ -907,30 +1006,71 @@ AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
 
 # Report on what we found.
-AC_MSG_NOTICE([])
-AC_MSG_NOTICE([**************************************************************])
-AC_MSG_NOTICE([ $PACKAGE_NAME])
-AC_MSG_NOTICE([ configured as follows:])
-AC_MSG_NOTICE([**************************************************************])
-AC_MSG_NOTICE([])
-AC_MSG_NOTICE([                    CC=$CC])
-AC_MSG_NOTICE([                CFLAGS=$CFLAGS])
-AC_MSG_NOTICE([         OPENMP_CFLAGS=$OPENMP_CFLAGS])
-AC_MSG_NOTICE([           SSE2_CFLAGS=$SSE2_CFLAGS])
-AC_MSG_NOTICE([          SSE41_CFLAGS=$SSE41_CFLAGS])
-AC_MSG_NOTICE([           AVX2_CFLAGS=$AVX2_CFLAGS])
-AC_MSG_NOTICE([        AVX512F_CFLAGS=$AVX512F_CFLAGS])
-AC_MSG_NOTICE([       AVX512BW_CFLAGS=$AVX512BW_CFLAGS])
-AC_MSG_NOTICE([     AVX512VBMI_CFLAGS=$AVX512VBMI_CFLAGS])
-AC_MSG_NOTICE([        ALTIVEC_CFLAGS=$ALTIVEC_CFLAGS])
-AC_MSG_NOTICE([                   CXX=$CXX])
-AC_MSG_NOTICE([              CXXFLAGS=$CXXFLAGS])
-AC_MSG_NOTICE([       OPENMP_CXXFLAGS=$OPENMP_CXXFLAGS])
-AC_MSG_NOTICE([                   CPP=$CPP])
-AC_MSG_NOTICE([              CPPFLAGS=$CPPFLAGS])
-AC_MSG_NOTICE([               LDFLAGS=$LDFLAGS])
-AC_MSG_NOTICE([                  LIBS=$LIBS])
-AC_MSG_NOTICE([            CLOCK_LIBS=$CLOCK_LIBS])
-AC_MSG_NOTICE([             MATH_LIBS=$MATH_LIBS])
-AC_MSG_NOTICE([              Z_CFLAGS=$Z_CFLAGS])
-AC_MSG_NOTICE([                Z_LIBS=$Z_LIBS])
+AX_RECURSIVE_EVAL([$bindir], [full_absolute_bindir])
+AX_RECURSIVE_EVAL([$libdir], [full_absolute_libdir])
+AX_RECURSIVE_EVAL([$includedir], [full_absolute_includedir])
+AX_RECURSIVE_EVAL([$pkgconfigdir], [full_absolute_pkgconfigdir])
+AC_MSG_RESULT([
+-=-=-=-=-=-=-=-=-=-= Configuration Complete =-=-=-=-=-=-=-=-=-=-=-
+
+  Configuration summary :
+
+    parasail version : .................... ${VERSION}
+
+    Host CPU : ............................ ${host_cpu}
+    Host Vendor : ......................... ${host_vendor}
+    Host OS : ............................. ${host_os}
+
+  Toolchain :
+
+    CC : .................................. ${CC} (${ax_cv_c_compiler_vendor}, ${ax_cv_c_compiler_version})
+    CXX : ................................. ${CXX} (${ax_cv_cxx_compiler_vendor}, ${ax_cv_cxx_compiler_version})
+
+  Flags :
+
+    CFLAGS : .............................. ${CFLAGS}
+    CXXFLAGS : ............................ ${CXXFLAGS}
+    CPPFLAGS : ............................ ${CPPFLAGS}
+    LDFLAGS : ............................. ${LDFLAGS}
+    LIBS : ................................ ${LIBS}
+
+  Intrinsics :
+
+    SSE2 : ................................ ${enable_sse2}
+    SSE2_CFLAGS : ......................... ${SSE2_CFLAGS}
+
+    SSE4.1 : .............................. ${enable_sse4_1}
+    SSE41_CFLAGS : ........................ ${SSE41_CFLAGS}
+
+    AVX2 : ................................ ${enable_avx2}
+    AVX2_CFLAGS : ......................... ${AVX2_CFLAGS}
+
+    AVX512 : .............................. ${enable_avx512}
+    AVX512F_CFLAGS : ...................... ${AVX512F_CFLAGS}
+    AVX512BW_CFLAGS : ..................... ${AVX512BW_CFLAGS}
+    AVX512VBMI_CFLAGS : ................... ${AVX512VBMI_CFLAGS}
+
+    Altivec : ............................. ${enable_altivec}
+    ALTIVEC_CFLAGS : ...................... ${ALTIVEC_CFLAGS}
+
+  Dependencies :
+
+    OPENMP_CFLAGS : ....................... ${OPENMP_CFLAGS}
+    OPENMP_CXXFLAGS : ..................... ${OPENMP_CXXFLAGS}
+
+    CLOCK_LIBS : .......................... ${CLOCK_LIBS}
+    MATH_LIBS : ........................... ${MATH_LIBS}
+    Z_CFLAGS : ............................ ${Z_CFLAGS}
+    Z_LIBS : .............................. ${Z_LIBS}
+
+  Installation directories :
+
+    Program directory : ................... ${full_absolute_bindir}
+    Library directory : ................... ${full_absolute_libdir}
+    Include directory : ................... ${full_absolute_includedir}
+    Pkgconfig directory : ................. ${full_absolute_pkgconfigdir}
+
+Compiling some other packages against parasail may require
+the addition of '$full_absolute_pkgconfigdir' to the
+PKG_CONFIG_PATH environment variable.
+])

--- a/m4/ax_compiler_vendor.m4
+++ b/m4/ax_compiler_vendor.m4
@@ -1,0 +1,88 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_compiler_vendor.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPILER_VENDOR
+#
+# DESCRIPTION
+#
+#   Determine the vendor of the C/C++ compiler, e.g., gnu, intel, ibm, sun,
+#   hp, borland, comeau, dec, cray, kai, lcc, metrowerks, sgi, microsoft,
+#   watcom, etc. The vendor is returned in the cache variable
+#   $ax_cv_c_compiler_vendor for C and $ax_cv_cxx_compiler_vendor for C++.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2008 Matteo Frigo
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 17
+
+AC_DEFUN([AX_COMPILER_VENDOR],
+[AC_CACHE_CHECK([for _AC_LANG compiler vendor], ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor,
+  dnl Please add if possible support to ax_compiler_version.m4
+  [# note: don't check for gcc first since some other compilers define __GNUC__
+  vendors="intel:     __ICC,__ECC,__INTEL_COMPILER
+           ibm:       __xlc__,__xlC__,__IBMC__,__IBMCPP__
+           pathscale: __PATHCC__,__PATHSCALE__
+           clang:     __clang__
+           cray:      _CRAYC
+           fujitsu:   __FUJITSU
+           sdcc:      SDCC, __SDCC
+           gnu:       __GNUC__
+           sun:       __SUNPRO_C,__SUNPRO_CC
+           hp:        __HP_cc,__HP_aCC
+           dec:       __DECC,__DECCXX,__DECC_VER,__DECCXX_VER
+           borland:   __BORLANDC__,__CODEGEARC__,__TURBOC__
+           comeau:    __COMO__
+           kai:       __KCC
+           lcc:       __LCC__
+           sgi:       __sgi,sgi
+           microsoft: _MSC_VER
+           metrowerks: __MWERKS__
+           watcom:    __WATCOMC__
+           portland:  __PGI
+	   tcc:       __TINYC__
+           unknown:   UNKNOWN"
+  for ventest in $vendors; do
+    case $ventest in
+      *:) vendor=$ventest; continue ;;
+      *)  vencpp="defined("`echo $ventest | sed 's/,/) || defined(/g'`")" ;;
+    esac
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,[
+      #if !($vencpp)
+        thisisanerror;
+      #endif
+    ])], [break])
+  done
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor=`echo $vendor | cut -d: -f1`
+ ])
+])

--- a/m4/ax_compiler_version.m4
+++ b/m4/ax_compiler_version.m4
@@ -1,0 +1,529 @@
+# ===========================================================================
+#   https://www.gnu.org/software/autoconf-archive/ax_compiler_version.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPILER_VERSION
+#
+# DESCRIPTION
+#
+#   This macro retrieves the compiler version and returns it in the cache
+#   variable $ax_cv_c_compiler_version for C and $ax_cv_cxx_compiler_version
+#   for C++.
+#
+#   Version is returned as epoch:major.minor.patchversion
+#
+#   Epoch is used in order to have an increasing version number in case of
+#   marketing change.
+#
+#   Epoch use: * borland compiler use chronologically 0turboc for turboc
+#   era,
+#
+#     1borlanc BORLANDC++ before 5, 2cppbuilder for cppbuilder era,
+#     3borlancpp for return of BORLANDC++ (after version 5.5),
+#     4cppbuilder for cppbuilder with year version,
+#     and 5xe for XE era.
+#
+#   An empty string is returned otherwise.
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Bastien ROUCARIES <roucaries.bastien+autoconf@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 12
+
+# for intel
+AC_DEFUN([_AX_COMPILER_VERSION_INTEL],
+  [ dnl
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    [__INTEL_COMPILER/100],,
+    AC_MSG_FAILURE([[[$0]] unknown intel compiler version]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    [(__INTEL_COMPILER%100)/10],,
+    AC_MSG_FAILURE([[[$0]] unknown intel compiler version]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+    [(__INTEL_COMPILER%10)],,
+    AC_MSG_FAILURE([[[$0]] unknown intel compiler version]))
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch"
+  ])
+
+# for IBM
+AC_DEFUN([_AX_COMPILER_VERSION_IBM],
+  [ dnl
+  dnl check between z/OS C/C++  and XL C/C++
+  AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM([],
+      [
+        #if defined(__COMPILER_VER__)
+        choke me;
+        #endif
+      ])],
+    [
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+        [__xlC__/100],,
+      	AC_MSG_FAILURE([[[$0]] unknown IBM compiler major version]))
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+        [__xlC__%100],,
+      	AC_MSG_FAILURE([[[$0]] unknown IBM compiler minor version]))
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+        [__xlC_ver__/0x100],,
+      	AC_MSG_FAILURE([[[$0]] unknown IBM compiler patch version]))
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_build,
+        [__xlC_ver__%0x100],,
+      	AC_MSG_FAILURE([[[$0]] unknown IBM compiler build version]))
+      ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_build"
+    ],
+    [
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+        [__xlC__%1000],,
+      	AC_MSG_FAILURE([[[$0]] unknown IBM compiler patch version]))
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+        [(__xlC__/10000)%10],,
+      	AC_MSG_FAILURE([[[$0]] unknown IBM compiler minor version]))
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+        [(__xlC__/100000)%10],,
+      	AC_MSG_FAILURE([[[$0]] unknown IBM compiler major version]))
+      ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch"
+    ])
+])
+
+# for pathscale
+AC_DEFUN([_AX_COMPILER_VERSION_PATHSCALE],[
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    __PATHCC__,,
+    AC_MSG_FAILURE([[[$0]] unknown pathscale major]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    __PATHCC_MINOR__,,
+    AC_MSG_FAILURE([[[$0]] unknown pathscale minor]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+    [__PATHCC_PATCHLEVEL__],,
+    AC_MSG_FAILURE([[[$0]] unknown pathscale patch level]))
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch"
+  ])
+
+# for clang
+AC_DEFUN([_AX_COMPILER_VERSION_CLANG],[
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    __clang_major__,,
+    AC_MSG_FAILURE([[[$0]] unknown clang major]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    __clang_minor__,,
+    AC_MSG_FAILURE([[[$0]] unknown clang minor]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+    [__clang_patchlevel__],,0)
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch"
+  ])
+
+# for crayc
+AC_DEFUN([_AX_COMPILER_VERSION_CRAY],[
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    _RELEASE,,
+    AC_MSG_FAILURE([[[$0]] unknown crayc release]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    _RELEASE_MINOR,,
+    AC_MSG_FAILURE([[[$0]] unknown crayc minor]))
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor"
+  ])
+
+# for fujitsu
+AC_DEFUN([_AX_COMPILER_VERSION_FUJITSU],[
+  AC_COMPUTE_INT(ax_cv_[]_AC_LANG_ABBREV[]_compiler_version,
+                 __FCC_VERSION,,
+		 AC_MSG_FAILURE([[[$0]]unknown fujitsu release]))
+  ])
+
+# for GNU
+AC_DEFUN([_AX_COMPILER_VERSION_GNU],[
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    __GNUC__,,
+    AC_MSG_FAILURE([[[$0]] unknown gcc major]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    __GNUC_MINOR__,,
+    AC_MSG_FAILURE([[[$0]] unknown gcc minor]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+    [__GNUC_PATCHLEVEL__],,
+    AC_MSG_FAILURE([[[$0]] unknown gcc patch level]))
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch"
+  ])
+
+# For sun
+AC_DEFUN([_AX_COMPILER_VERSION_SUN],[
+  m4_define([_AX_COMPILER_VERSION_SUN_NUMBER],
+            [
+	     #if defined(__SUNPRO_CC)
+	     __SUNPRO_CC
+	     #else
+	     __SUNPRO_C
+	     #endif
+	    ])
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_until59,
+    !!(_AX_COMPILER_VERSION_SUN_NUMBER < 0x1000),,
+    AC_MSG_FAILURE([[[$0]] unknown sun release version]))
+  AS_IF([test "X$_ax_[]_AC_LANG_ABBREV[]_compiler_version_until59" = X1],
+    [dnl
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+        _AX_COMPILER_VERSION_SUN_NUMBER % 0x10,,
+	AC_MSG_FAILURE([[[$0]] unknown sun patch version]))
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+        (_AX_COMPILER_VERSION_SUN_NUMBER / 0x10) % 0x10,,
+        AC_MSG_FAILURE([[[$0]] unknown sun minor version]))
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+        (_AX_COMPILER_VERSION_SUN_NUMBER / 0x100),,
+        AC_MSG_FAILURE([[[$0]] unknown sun major version]))
+    ],
+    [dnl
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+        _AX_COMPILER_VERSION_SUN_NUMBER % 0x10,,
+        AC_MSG_FAILURE([[[$0]] unknown sun patch version]))
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+        (_AX_COMPILER_VERSION_SUN_NUMBER / 0x100) % 0x100,,
+        AC_MSG_FAILURE([[[$0]] unknown sun minor version]))
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+        (_AX_COMPILER_VERSION_SUN_NUMBER / 0x1000),,
+        AC_MSG_FAILURE([[[$0]] unknown sun major version]))
+    ])
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch"
+])
+
+AC_DEFUN([_AX_COMPILER_VERSION_HP],[
+  m4_define([_AX_COMPILER_VERSION_HP_NUMBER],
+            [
+	     #if defined(__HP_cc)
+	     __HP_cc
+	     #else
+	     __HP_aCC
+	     #endif
+	    ])
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_untilA0121,
+    !!(_AX_COMPILER_VERSION_HP_NUMBER <= 1),,
+    AC_MSG_FAILURE([[[$0]] unknown hp release version]))
+  AS_IF([test "X$_ax_[]_AC_LANG_ABBREV[]_compiler_version_untilA0121" = X1],
+    [dnl By default output last version with this behavior.
+     dnl it is so old
+      ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="01.21.00"
+    ],
+    [dnl
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+        (_AX_COMPILER_VERSION_HP_NUMBER % 100),,
+        AC_MSG_FAILURE([[[$0]] unknown hp release version]))
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+        ((_AX_COMPILER_VERSION_HP_NUMBER / 100)%100),,
+        AC_MSG_FAILURE([[[$0]] unknown hp minor version]))
+      AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+        ((_AX_COMPILER_VERSION_HP_NUMBER / 10000)%100),,
+        AC_MSG_FAILURE([[[$0]] unknown hp major version]))
+      ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch"
+    ])
+])
+
+AC_DEFUN([_AX_COMPILER_VERSION_DEC],[dnl
+  m4_define([_AX_COMPILER_VERSION_DEC_NUMBER],
+            [
+	     #if defined(__DECC_VER)
+	     __DECC_VER
+	     #else
+	     __DECCXX_VER
+	     #endif
+	    ])
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+    (_AX_COMPILER_VERSION_DEC_NUMBER % 10000),,
+    AC_MSG_FAILURE([[[$0]] unknown dec release version]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    ((_AX_COMPILER_VERSION_DEC_NUMBER / 100000UL)%100),,
+    AC_MSG_FAILURE([[[$0]] unknown dec minor version]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    ((_AX_COMPILER_VERSION_DEC_NUMBER / 10000000UL)%100),,
+    AC_MSG_FAILURE([[[$0]] unknown dec major version]))
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch"
+  ])
+
+# borland
+AC_DEFUN([_AX_COMPILER_VERSION_BORLAND],[dnl
+  m4_define([_AX_COMPILER_VERSION_TURBOC_NUMBER],
+            [
+	     #if defined(__TURBOC__)
+	     __TURBOC__
+	     #else
+	     choke me
+	     #endif
+	    ])
+  m4_define([_AX_COMPILER_VERSION_BORLANDC_NUMBER],
+            [
+	     #if defined(__BORLANDC__)
+	     __BORLANDC__
+	     #else
+	     __CODEGEARC__
+	     #endif
+	    ])
+ AC_COMPILE_IFELSE(
+   [AC_LANG_PROGRAM(,
+     _AX_COMPILER_VERSION_TURBOC_NUMBER)],
+   [dnl TURBOC
+     AC_COMPUTE_INT(
+       _ax_[]_AC_LANG_ABBREV[]_compiler_version_turboc_raw,
+       _AX_COMPILER_VERSION_TURBOC_NUMBER,,
+       AC_MSG_FAILURE([[[$0]] unknown turboc version]))
+     AS_IF(
+       [test $_ax_[]_AC_LANG_ABBREV[]_compiler_version_turboc_raw -lt 661 || test $_ax_[]_AC_LANG_ABBREV[]_compiler_version_turboc_raw -gt 1023],
+       [dnl compute normal version
+        AC_COMPUTE_INT(
+	  _ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+	  _AX_COMPILER_VERSION_TURBOC_NUMBER % 0x100,,
+	  AC_MSG_FAILURE([[[$0]] unknown turboc minor version]))
+	AC_COMPUTE_INT(
+	  _ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+	  (_AX_COMPILER_VERSION_TURBOC_NUMBER/0x100)%0x100,,
+	  AC_MSG_FAILURE([[[$0]] unknown turboc major version]))
+	ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="0turboc:$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor"],
+      [dnl special version
+       AS_CASE([$_ax_[]_AC_LANG_ABBREV[]_compiler_version_turboc_raw],
+         [661],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="0turboc:1.00"],
+	 [662],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="0turboc:1.01"],
+         [663],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="0turboc:2.00"],
+	 [
+	 AC_MSG_WARN([[[$0]] unknown turboc version between 0x295 and 0x400 please report bug])
+	 ax_cv_[]_AC_LANG_ABBREV[]_compiler_version=""
+	 ])
+      ])
+    ],
+    # borlandc
+    [
+    AC_COMPUTE_INT(
+      _ax_[]_AC_LANG_ABBREV[]_compiler_version_borlandc_raw,
+      _AX_COMPILER_VERSION_BORLANDC_NUMBER,,
+      AC_MSG_FAILURE([[[$0]] unknown borlandc version]))
+    AS_CASE([$_ax_[]_AC_LANG_ABBREV[]_compiler_version_borlandc_raw],
+      dnl BORLANDC++ before 5.5
+      [512] ,[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="1borlanc:2.00"],
+      [1024],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="1borlanc:3.00"],
+      [1024],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="1borlanc:3.00"],
+      [1040],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="1borlanc:3.1"],
+      [1106],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="1borlanc:4.0"],
+      [1280],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="1borlanc:5.0"],
+      [1312],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="1borlanc:5.02"],
+      dnl C++ Builder era
+      [1328],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="2cppbuilder:3.0"],
+      [1344],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="2cppbuilder:4.0"],
+      dnl BORLANDC++ after 5.5
+      [1360],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="3borlancpp:5.5"],
+      [1361],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="3borlancpp:5.51"],
+      [1378],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="3borlancpp:5.6.4"],
+      dnl C++ Builder with year number
+      [1392],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="4cppbuilder:2006"],
+      [1424],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="4cppbuilder:2007"],
+      [1555],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="4cppbuilder:2009"],
+      [1569],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="4cppbuilder:2010"],
+      dnl XE version
+      [1584],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="5xe"],
+      [1600],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="5xe:2"],
+      [1616],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="5xe:3"],
+      [1632],[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="5xe:4"],
+      [
+      AC_MSG_WARN([[[$0]] Unknown borlandc compiler version $_ax_[]_AC_LANG_ABBREV[]_compiler_version_borlandc_raw please report bug])
+      ])
+    ])
+  ])
+
+# COMO
+AC_DEFUN([_AX_COMPILER_VERSION_COMEAU],
+  [ dnl
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    [__COMO_VERSION__%100],,
+    AC_MSG_FAILURE([[[$0]] unknown comeau compiler minor version]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    [(__COMO_VERSION__/100)%10],,
+    AC_MSG_FAILURE([[[$0]] unknown comeau compiler major version]))
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor"
+  ])
+
+# KAI
+AC_DEFUN([_AX_COMPILER_VERSION_KAI],[
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+    [__KCC_VERSION%100],,
+    AC_MSG_FAILURE([[[$0]] unknown kay compiler patch version]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    [(__KCC_VERSION/100)%10],,
+    AC_MSG_FAILURE([[[$0]] unknown kay compiler minor version]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    [(__KCC_VERSION/1000)%10],,
+    AC_MSG_FAILURE([[[$0]] unknown kay compiler major version]))
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch"
+  ])
+
+dnl LCC
+dnl LCC does not output version...
+
+# SGI
+AC_DEFUN([_AX_COMPILER_VERSION_SGI],[
+   m4_define([_AX_COMPILER_VERSION_SGI_NUMBER],
+            [
+	     #if defined(_COMPILER_VERSION)
+	     _COMPILER_VERSION
+	     #else
+	     _SGI_COMPILER_VERSION
+	     #endif
+	    ])
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+    [_AX_COMPILER_VERSION_SGI_NUMBER%10],,
+    AC_MSG_FAILURE([[[$0]] unknown SGI compiler patch version]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    [(_AX_COMPILER_VERSION_SGI_NUMBER/10)%10],,
+    AC_MSG_FAILURE([[[$0]] unknown SGI compiler minor version]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    [(_AX_COMPILER_VERSION_SGI_NUMBER/100)%10],,
+    AC_MSG_FAILURE([[[$0]] unknown SGI compiler major version]))
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch"
+  ])
+
+# microsoft
+AC_DEFUN([_AX_COMPILER_VERSION_MICROSOFT],[
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    _MSC_VER%100,,
+    AC_MSG_FAILURE([[[$0]] unknown microsoft compiler minor version]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    (_MSC_VER/100)%100,,
+    AC_MSG_FAILURE([[[$0]] unknown microsoft compiler major version]))
+  dnl could be overridden
+  _ax_[]_AC_LANG_ABBREV[]_compiler_version_patch=0
+  _ax_[]_AC_LANG_ABBREV[]_compiler_version_build=0
+  # special case for version 6
+  AS_IF([test "X$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major" = "X12"],
+    [AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+       _MSC_FULL_VER%1000,,
+       _ax_[]_AC_LANG_ABBREV[]_compiler_version_patch=0)])
+  # for version 7
+  AS_IF([test "X$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major" = "X13"],
+    [AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+       _MSC_FULL_VER%1000,,
+       AC_MSG_FAILURE([[[$0]] unknown microsoft compiler patch version]))
+    ])
+  # for version > 8
+ AS_IF([test $_ax_[]_AC_LANG_ABBREV[]_compiler_version_major -ge 14],
+    [AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+       _MSC_FULL_VER%10000,,
+       AC_MSG_FAILURE([[[$0]] unknown microsoft compiler patch version]))
+    ])
+ AS_IF([test $_ax_[]_AC_LANG_ABBREV[]_compiler_version_major -ge 15],
+    [AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_build,
+       _MSC_BUILD,,
+       AC_MSG_FAILURE([[[$0]] unknown microsoft compiler build version]))
+    ])
+ ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_build"
+ ])
+
+# for metrowerks
+AC_DEFUN([_AX_COMPILER_VERSION_METROWERKS],[dnl
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+    __MWERKS__%0x100,,
+    AC_MSG_FAILURE([[[$0]] unknown metrowerks compiler patch version]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    (__MWERKS__/0x100)%0x10,,
+    AC_MSG_FAILURE([[[$0]] unknown metrowerks compiler minor version]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    (__MWERKS__/0x1000)%0x10,,
+    AC_MSG_FAILURE([[[$0]] unknown metrowerks compiler major version]))
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch"
+  ])
+
+# for watcom
+AC_DEFUN([_AX_COMPILER_VERSION_WATCOM],[dnl
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    __WATCOMC__%100,,
+    AC_MSG_FAILURE([[[$0]] unknown watcom compiler minor version]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    (__WATCOMC__/100)%100,,
+    AC_MSG_FAILURE([[[$0]] unknown watcom compiler major version]))
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor"
+  ])
+
+# for PGI
+AC_DEFUN([_AX_COMPILER_VERSION_PORTLAND],[
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    __PGIC__,,
+    AC_MSG_FAILURE([[[$0]] unknown pgi major]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    __PGIC_MINOR__,,
+    AC_MSG_FAILURE([[[$0]] unknown pgi minor]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+    [__PGIC_PATCHLEVEL__],,
+    AC_MSG_FAILURE([[[$0]] unknown pgi patch level]))
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch"
+  ])
+
+# tcc
+AC_DEFUN([_AX_COMPILER_VERSION_TCC],[
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version=[`tcc -v | $SED 's/^[ ]*tcc[ ]\+version[ ]\+\([0-9.]\+\).*/\1/g'`]
+  ])
+
+# for GNU
+AC_DEFUN([_AX_COMPILER_VERSION_SDCC],[
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    /* avoid parse error with comments */
+    #if(defined(__SDCC_VERSION_MAJOR))
+	__SDCC_VERSION_MAJOR
+    #else
+	SDCC/100
+    #endif
+    ,,
+    AC_MSG_FAILURE([[[$0]] unknown sdcc major]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    /* avoid parse error with comments */
+    #if(defined(__SDCC_VERSION_MINOR))
+	__SDCC_VERSION_MINOR
+    #else
+	(SDCC%100)/10
+    #endif
+    ,,
+    AC_MSG_FAILURE([[[$0]] unknown sdcc minor]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+    [
+    /* avoid parse error with comments */
+    #if(defined(__SDCC_VERSION_PATCH))
+	__SDCC_VERSION_PATCH
+    #elsif(defined(_SDCC_VERSION_PATCHLEVEL))
+	__SDCC_VERSION_PATCHLEVEL
+    #else
+	SDCC%10
+    #endif
+    ],,
+    AC_MSG_FAILURE([[[$0]] unknown sdcc patch level]))
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch"
+  ])
+
+# main entry point
+AC_DEFUN([AX_COMPILER_VERSION],[dnl
+  AC_REQUIRE([AX_COMPILER_VENDOR])
+  AC_REQUIRE([AC_PROG_SED])
+  AC_CACHE_CHECK([for _AC_LANG compiler version],
+    ax_cv_[]_AC_LANG_ABBREV[]_compiler_version,
+    [ dnl
+      AS_CASE([$ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor],
+        [intel],[_AX_COMPILER_VERSION_INTEL],
+	[ibm],[_AX_COMPILER_VERSION_IBM],
+	[pathscale],[_AX_COMPILER_VERSION_PATHSCALE],
+	[clang],[_AX_COMPILER_VERSION_CLANG],
+	[cray],[_AX_COMPILER_VERSION_CRAY],
+	[fujitsu],[_AX_COMPILER_VERSION_FUJITSU],
+        [gnu],[_AX_COMPILER_VERSION_GNU],
+	[sun],[_AX_COMPILER_VERSION_SUN],
+	[hp],[_AX_COMPILER_VERSION_HP],
+	[dec],[_AX_COMPILER_VERSION_DEC],
+	[borland],[_AX_COMPILER_VERSION_BORLAND],
+	[comeau],[_AX_COMPILER_VERSION_COMEAU],
+	[kai],[_AX_COMPILER_VERSION_KAI],
+	[sgi],[_AX_COMPILER_VERSION_SGI],
+	[microsoft],[_AX_COMPILER_VERSION_MICROSOFT],
+	[metrowerks],[_AX_COMPILER_VERSION_METROWERKS],
+	[watcom],[_AX_COMPILER_VERSION_WATCOM],
+	[portland],[_AX_COMPILER_VERSION_PORTLAND],
+	[tcc],[_AX_COMPILER_VERSION_TCC],
+	[sdcc],[_AX_COMPILER_VERSION_SDCC],
+  	[ax_cv_[]_AC_LANG_ABBREV[]_compiler_version=""])
+    ])
+])

--- a/m4/ax_recursive_eval.m4
+++ b/m4/ax_recursive_eval.m4
@@ -1,0 +1,56 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_recursive_eval.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_RECURSIVE_EVAL(VALUE, RESULT)
+#
+# DESCRIPTION
+#
+#   Interpolate the VALUE in loop until it doesn't change, and set the
+#   result to $RESULT. WARNING: It's easy to get an infinite loop with some
+#   unsane input.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Alexandre Duret-Lutz <adl@gnu.org>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 1
+
+AC_DEFUN([AX_RECURSIVE_EVAL],
+[_lcl_receval="$1"
+$2=`(test "x$prefix" = xNONE && prefix="$ac_default_prefix"
+     test "x$exec_prefix" = xNONE && exec_prefix="${prefix}"
+     _lcl_receval_old=''
+     while test "[$]_lcl_receval_old" != "[$]_lcl_receval"; do
+       _lcl_receval_old="[$]_lcl_receval"
+       eval _lcl_receval="\"[$]_lcl_receval\""
+     done
+     echo "[$]_lcl_receval")`])


### PR DESCRIPTION
Hi @jeffdaily 
as part of our cross-compilation build, we need to be in full control of which intrinsics are enabled exactly. I've added a bunch of `--enable` flags in order to make the choice of instruction set explicit. By default, `./configure` will still try to autodetect the available instruction set, but explicitly enabling it and not finding an instruction set causes a hard error:

```
$ ./configure --enable-altivec
[...]
checking for AltiVec support... no
configure: error: You explicitly requested Altivec support, but Altivec CFLAGS could not be found!
```

For deployment scenarios, using automagically detected features is a problem, because the build machine might have features that might not be available on the deployed machines.

Furthermore, I have removed testing the `-march=` flags. These are extremely fragile and not just add support for intrinsics, they actively make the produced ABI incompatible with everything before. After you found situations where `-march=core2` worked but `-mavx` hasn't? In Gentoo, `-march=` should only ever be added by the user, not the build system itself.

Finally, I've polished up the final report output to make it a bit more detailed, with compiler version and installation paths.