### PR TITLE
Fix tarball

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ script:
   - if [[ "$BUILD_TYPE" == "make" ]]; then autoreconf -fi; fi
   - if [[ "$BUILD_TYPE" == "make" ]]; then ./configure $MAYBE_CROSS || cat config.log; fi
   - if [[ "$BUILD_TYPE" == "make" ]]; then make -j 4; fi
-  - if [[ "$BUILD_TYPE" == "make" ]]; then make check -j 4; fi
+  - if [[ "$BUILD_TYPE" == "make" ]]; then make distcheck -j 4; fi
   - if [[ "$BUILD_TYPE" == "make" ]]; then make dist; fi
   - if [[ "$BUILD_TYPE" == "make" ]]; then make dist-zip; fi
   - if [[ "$BUILD_TYPE" == "make" ]]; then mkdir dist; fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -202,6 +202,7 @@ SRC_CORE += src/time.c
 SRC_CORE += src/nw_dispatch.c
 SRC_CORE += src/sg_dispatch.c
 SRC_CORE += src/sw_dispatch.c
+SRC_CORE += src/sg_helper.h
 SRC_CORE += src/sg_qb_dispatch.c
 SRC_CORE += src/sg_qe_dispatch.c
 SRC_CORE += src/sg_qx_dispatch.c
@@ -1472,3 +1473,9 @@ EXTRA_DIST += src/meson.build
 EXTRA_DIST += tests/meson.build
 EXTRA_DIST += meson_options.txt
 EXTRA_DIST += src/dummy.c
+
+DISTCLEANFILES =
+DISTCLEANFILES += parasail-1-uninstalled.sh
+DISTCLEANFILES += parasail-1-uninstalled.pc
+DISTCLEANFILES += parasail-1.pc
+DISTCLEANFILES += parasail-1.pc.in


### PR DESCRIPTION
Hi @jeffdaily 
your latest tarballs are missing a header. I've added it in `Makefile.am` and changed Travis to use `make distcheck`, which catches such issues (it tries to build the package out-of-source using the produced tarball). Could we cut a new release after merging my fixes?